### PR TITLE
Fix numerizer fraction cleanup bad behaviour

### DIFF
--- a/numerizer/numerizer.py
+++ b/numerizer/numerizer.py
@@ -263,7 +263,7 @@ def cleanup_fractions(s):
         s = re.sub(pat, _repl_frac_cleanup, s)
 
     # fix unpreceded fractions
-    s = re.sub(r'(?:^|\W)\/(\d+)', r'1/\1', s)
+    s = re.sub(r'(?:(?<=^)|(?<=[^\w)]))\/(\d+)', r'1/\1', s)
     s = re.sub(r'(?<=[a-zA-Z])\/(\d+)', r'1/\1', s)
     return s
 

--- a/test_numerize.py
+++ b/test_numerize.py
@@ -123,6 +123,10 @@ def test_compatability():
     assert '05/06' == numerize('05/06')
     assert "3.5 hours" == numerize("three and a half hours")
     assert "1/2 an hour" == numerize("half an hour")
+    assert "(1/2)+2" == numerize("(1/2)+2")
+    assert "(10+10)/2" == numerize("(10+10)/2")
+    assert "(10+10)/2" == numerize("(10+10)/two")
+    assert "2*(45+21)/6" == numerize("2*(45+21)/6")
 
 
 def test_ordinal_strings():


### PR DESCRIPTION
[Numerizer](https://pypi.org/project/numerizer/) is a Python library that provides logic "_to convert natural language numerics into ints and floats_". 

From an issue reported on Seekr, we found that the library contains a not expected behaviour described [on the following issue](https://github.com/jaidevd/numerizer/issues/16).
The fix we found is to change the regular expression found in the line 266 on _numerizer.py_ that had the intention to find non word type symbols with `\W`, but that conflicted with grouped terms (that uses parenthesis)